### PR TITLE
0 Compiler warnings (gcc -Wall -Wextra) and PI definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ demos/offline/audio
 build/
 a.out
 .DS_Store
+src/*.o

--- a/src/BTT.c
+++ b/src/BTT.c
@@ -708,7 +708,7 @@ void btt_spectral_flux_stft_callback(void* SELF, dft_sample_t* real, int N)
   
   if((self->tracking_mode == BTT_ONSET_AND_TEMPO_TRACKING) ||
      (self->tracking_mode == BTT_ONSET_AND_TEMPO_AND_BEAT_TRACKING))
-      if(self->num_oss_frames_processed >= self->oss_length)
+      if((int) self->num_oss_frames_processed >= self->oss_length)
         btt_tempo_tracking(self);
 
   if(self->tracking_mode >= BTT_ONSET_AND_TEMPO_AND_BEAT_TRACKING)

--- a/src/DFT.c
+++ b/src/DFT.c
@@ -12,6 +12,9 @@
 #include <math.h>
 #include <float.h>
 
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
 /*-----------------------------------------------------------------------*/
 //produces output in bit-reversed order (Decimation in Frequency)
 void dft_raw_forward_dft(dft_sample_t* real, dft_sample_t* imag, int N)
@@ -664,11 +667,11 @@ void   rdft_real_generalized_autocorrelation  (dft_sample_t* real, int N, double
 
 
 /*-----------------------------------------------------------------------*/
-void rdft_bit_reverse_indices(dft_sample_t* real, int N)
+void rdft_bit_reverse_indices(dft_sample_t* real, unsigned int N)
 {
   dft_sample_t temp;
   
-  int N_over_2 = N >> 1;
+  unsigned int N_over_2 = N >> 1;
   unsigned n, bit, rev;
   unsigned n_reversed = N_over_2;
   
@@ -687,10 +690,10 @@ void rdft_bit_reverse_indices(dft_sample_t* real, int N)
 }
 
 /*-----------------------------------------------------------------------*/
-void dft_bit_reverse_indices(dft_sample_t* real, dft_sample_t* imag, int N)
+void dft_bit_reverse_indices(dft_sample_t* real, dft_sample_t* imag, unsigned int N)
 {
   dft_sample_t temp;
-  int N_over_2 = N >> 1;
+  unsigned int N_over_2 = N >> 1;
   unsigned n, bit, rev;
   unsigned n_reversed = N_over_2;
   

--- a/src/DFT.h
+++ b/src/DFT.h
@@ -21,7 +21,7 @@ void   dft_apply_window         (dft_sample_t* real,   dft_sample_t* window, int
 
 void   dft_raw_forward_dft      (dft_sample_t* real,   dft_sample_t* imag,   int N);
 void   dft_raw_inverse_dft      (dft_sample_t* real,   dft_sample_t* imag,   int N);
-void   dft_bit_reverse_indices  (dft_sample_t* real,   dft_sample_t* imag,   int N);
+void   dft_bit_reverse_indices  (dft_sample_t* real,   dft_sample_t* imag,   unsigned int N);
 void   dft_complex_forward_dft  (dft_sample_t* real,   dft_sample_t* imag,   int N);
 void   dft_complex_inverse_dft  (dft_sample_t* real,   dft_sample_t* imag,   int N);
 
@@ -45,7 +45,7 @@ void   dft_2_real_inverse_dfts  (dft_sample_t* real_1, dft_sample_t* real_2, dft
   half the space of dft_real_forward_dft.
 */
 
-void   rdft_bit_reverse_indices (dft_sample_t* real, int N);
+void   rdft_bit_reverse_indices (dft_sample_t* real, unsigned int N);
 void   rdft_real_forward_dft    (dft_sample_t* real,  int N);
 void   rdft_real_inverse_dft    (dft_sample_t* real,  int N);
 void   rdft_2_real_forward_dfts (dft_sample_t* real_1, dft_sample_t* real_2, int N);

--- a/src/Filter.c
+++ b/src/Filter.c
@@ -2,6 +2,9 @@
 #include "math.h"
 #include <stdlib.h>
 
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
 #define TWO_PI (M_PI * 2.0)
 
 /*-------------------------------------------------*/

--- a/src/Filter.c
+++ b/src/Filter.c
@@ -50,7 +50,7 @@ Filter* filter_new(filter_type_t type, float cutoff, int order)
       if(self->coeffs == NULL) return filter_destroy(self);
       filter_set_window_type(self, FILTER_WINDOW_BLACKMANN); //triggers calculation of window and coeffs
     }
-  
+
   return self;
 }
 
@@ -82,9 +82,9 @@ void            filter_clear          (Filter* self)
 /*-------------------------------------------------*/
 void filter_set_filter_type(Filter* self, filter_type_t type)
 {
-  if((self->type == type) /*|| (type < 0)*/ || (type >= FILTER_NUMBER_OF_TYPES)) 
+  if((self->type == type) /*|| (type < 0)*/ || (type >= FILTER_NUMBER_OF_TYPES))
     return;
-  
+
   self->type = type;
   filter_set_cutoff(self, self->cutoff);
 }
@@ -113,10 +113,10 @@ void filter_set_cutoff(Filter* self, float cutoff)
 {
   self->cutoff = cutoff;
   void (*init_coeffs)(Filter*) = NULL;
-  
+
   switch(self->type)
     {
-      case FILTER_LOW_PASS : 
+      case FILTER_LOW_PASS :
         init_coeffs = filter_init_lowpass_coeffs;
         break;
       case FILTER_HIGH_PASS:
@@ -166,10 +166,10 @@ void filter_set_window_type(Filter* self, filter_window_t window)
 
   self->window_type = window;
   void (*init_window)(Filter*) = NULL;
-  
+
   switch(self->window_type)
     {
-      case FILTER_WINDOW_RECT : 
+      case FILTER_WINDOW_RECT :
         init_window = filter_init_rect_window;
         break;
       case FILTER_WINDOW_HANN:
@@ -187,7 +187,7 @@ void filter_set_window_type(Filter* self, filter_window_t window)
   if(init_window != NULL)
     init_window(self);
 
-  filter_set_cutoff(self, self->cutoff);  
+  filter_set_cutoff(self, self->cutoff);
 }
 
 /*-------------------------------------------------*/
@@ -202,7 +202,7 @@ void filter_init_lowpass_coeffs(Filter* self)
   int i, n=self->order+1;
   float m_over_2 = self->order / 2.0;
   float f_t = self->cutoff / self->sample_rate;
-  float two_pi_f_t = TWO_PI * f_t;  
+  float two_pi_f_t = TWO_PI * f_t;
   float i_minus_m_over_2;
   float temp;
 
@@ -219,7 +219,7 @@ void filter_init_lowpass_coeffs(Filter* self)
 
       temp *= self->window[i];
       self->coeffs[i] = temp;
-    }  
+    }
 }
 
 /*-------------------------------------------------*/
@@ -232,7 +232,7 @@ void filter_init_highpass_coeffs(Filter* self)
   int i, n=self->order+1;
   float m_over_2 = self->order / 2.0;
   float f_t = self->cutoff / self->sample_rate;
-  float two_pi_f_t = TWO_PI * f_t;  
+  float two_pi_f_t = TWO_PI * f_t;
   float i_minus_m_over_2;
   float temp;
 
@@ -262,7 +262,7 @@ void filter_init_bandpass_coeffs(Filter* self)
   float two_pi_f_t = TWO_PI * f_t;
   float i_minus_m_over_2;
   float temp;
-  
+
   for(i=0; i<n; i++)
     {
       if(i != m_over_2)
@@ -283,7 +283,7 @@ void filter_init_bandpass_coeffs(Filter* self)
 /*-------------------------------------------------*/
 void filter_init_bandstop_coeffs(Filter* self)
 {
-
+    (void) self;
 }
 
 /*-------------------------------------------------*/
@@ -318,7 +318,7 @@ void filter_init_hamming_window(Filter* self)
     {
       self->window[i] = 0.54 - 0.46 * cos(phase);
       phase += phase_increment;
-    }  
+    }
 }
 
 /*-------------------------------------------------*/
@@ -331,12 +331,12 @@ void filter_init_blackmann_window(Filter* self)
   double a0 = (1-a)/2.0;
   double a1 = 1/2.0;
   double a2 = a/2.0;
-  
+
   for(i=0; i<n; i++)
     {
       self->window[i] = a0 - a1*cos(phase) + a2*cos(2*phase);
       phase += phase_increment;
-    } 
+    }
 }
 
 /*-------------------------------------------------*/
@@ -353,11 +353,10 @@ void    filter_process_data(Filter* self, float* data, int num_samples)
       self->prev_samples[0] = *data;
 
       //calculate filter output
-      output = 0;      
+      output = 0;
       for(i=0; i<n; i++)
         output += self->prev_samples[i] * self->coeffs[i];
 
       *data++ = output;
     }
 }
-

--- a/src/STFT.c
+++ b/src/STFT.c
@@ -12,7 +12,7 @@ struct Opaque_STFT_Struct
   int           hop_size;
   int           sample_counter;
   int           input_index;
-  int           output_index;;
+  int           output_index;
   dft_sample_t* window;
   dft_sample_t* running_input;
   dft_sample_t* running_output;
@@ -144,7 +144,7 @@ struct Opaque_TWO_STFTS_Struct
   int           hop_size;
   int           sample_counter;
   int           input_index;
-  int           output_index;;
+  int           output_index;
   dft_sample_t* window;
   dft_sample_t* running_input;
   dft_sample_t* running_output;

--- a/src/Statistics.c
+++ b/src/Statistics.c
@@ -12,6 +12,9 @@
 #include <stdlib.h>
 #include <string.h> //memset, memcpy
 
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
 /*--------------------------------------------------------------------*/
 /*--___-------_-_-------------------------------------------------------
    / _ \ _ _ | (_)_ _  ___    /_\__ _____ _ _ __ _ __ _ ___ 
@@ -211,7 +214,7 @@ void moving_average_update(MovingAverage* self, double     x)
   ++self->current_sample_index;
   self->current_sample_index %= self->N;
 
-  if(online_average_n(self->online) < self->N)
+  if((unsigned int) online_average_n(self->online) < self->N)
     {
       online_average_update(self->online, x);
       self->variance = online_average_variance(self->online);
@@ -225,7 +228,7 @@ void moving_average_update(MovingAverage* self, double     x)
       self->variance = self->s / self->N;
       self->mean     = new_mean;
     }
-};
+}
 
 /*--------------------------------------------------------------------*/
 /*--___-------_-_------------___------------------------_---------------
@@ -496,13 +499,13 @@ double     adaptive_threshold_update(AdaptiveThreshold* self, double     x)
   self->onset_signal = next;
   
   return result;
-};
+}
 
 
 /*--------------------------------------------------------------------*/
 double     statistics_random_flat()
 {
-  return random() / (double)RAND_MAX;
+  return rand() / (double)RAND_MAX;
 }
 
 /*--------------------------------------------------------------------*/

--- a/src/fastsin.h
+++ b/src/fastsin.h
@@ -21,7 +21,7 @@ float fastcos  (fastsin_t angle);
 #define fastsin(angle) (*(sinTable + ((angle) >> 20)))
 #define fastcos(angle) (*(sinTable + (((angle) + SIN_HALF_PI) >> 20)))
 
-const extern float sinTable[SIN_NUM_SAMPLES];
+extern const float sinTable[SIN_NUM_SAMPLES];
 
 
 //slowsin


### PR DESCRIPTION
Explicit casting was used to get rid of gcc's compiler warnings. Also some variables had their declaration changed from signed to unsigned. 
M_PI was not defined by my platform's <math.h> so I thought it would be good to have the respective #ifndef #define
Although having it in 3 different files isn't really neat, I think it would not make much sense to have another header file just for M_PI.
